### PR TITLE
Remove deprecated get_fields_with_model call

### DIFF
--- a/django_postgres_pgpfields/managers.py
+++ b/django_postgres_pgpfields/managers.py
@@ -39,5 +39,5 @@ class PGPEncryptedManager(models.Manager):
                     settings.PGPFIELDS_PRIVATE_KEY,
                 )
                 encrypted_fields.append(field.name)
-        return PGPEncryptedManager.get_queryset(
+        return models.Manager.get_queryset(self,
             *args, **kwargs).defer(*encrypted_fields).extra(select=select_sql)

--- a/django_postgres_pgpfields/managers.py
+++ b/django_postgres_pgpfields/managers.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from django_postgres_pgpfields.mixins import PGPMixin
 
-
+#pylint: disable=W0212
 class PGPEncryptedManager(models.Manager):
     """Custom manager to decrypt values at query time."""
 
@@ -19,11 +19,18 @@ class PGPEncryptedManager(models.Manager):
         else:
             return """pgp_pub_decrypt("{0}"."{1}", dearmor('{2}'))"""
 
+    @staticmethod
+    def _get_fields(model_cls):
+        return [
+            (f, f.model if f.model != model_cls else None) for f in model_cls._meta.get_fields()
+            if not f.is_relation or f.one_to_one or (f.many_to_one and f.related_model)
+        ]
+
     def get_queryset(self, *args, **kwargs):
         """Django queryset.extra() is used here to add decryption sql to query."""
         select_sql = {}
         encrypted_fields = []
-        for f in self.model._meta.get_fields_with_model():
+        for f in self._get_fields(self.model):
             field = f[0]
             if isinstance(field, PGPMixin):
                 select_sql[field.name] = self.get_decrypt_sql(field).format(
@@ -32,5 +39,5 @@ class PGPEncryptedManager(models.Manager):
                     settings.PGPFIELDS_PRIVATE_KEY,
                 )
                 encrypted_fields.append(field.name)
-        return super(PGPEncryptedManager, self).get_queryset(
+        return PGPEncryptedManager.get_queryset(
             *args, **kwargs).defer(*encrypted_fields).extra(select=select_sql)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = '0.0.3'
+version = '0.0.4'
 
 setup(
     name='django-postgres-pgpfields',


### PR DESCRIPTION
In preparation for Django 1.11, switch from `get_fields_with_model` to `get_fields`